### PR TITLE
fix: update swagger docs with format specifications

### DIFF
--- a/control-plane/docs/docs.go
+++ b/control-plane/docs/docs.go
@@ -2854,7 +2854,8 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int32"
                             }
                         }
                     },
@@ -3620,8 +3621,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/domain.CommonLbConfig"
                 },
                 "connectionIdleTimeout": {
-                    "description": "interval of HTTP connection inactivity before closing, unit: seconds"
-                    "type": "integer"
+                    "$ref": "#/definitions/domain.NullInt"
                 },
                 "dnsResolvers": {
                     "type": "array",
@@ -3710,6 +3710,7 @@ const docTemplate = `{
         },
         "domain.ConfigPriority": {
             "type": "integer",
+            "format": "int32",
             "enum": [
                 0,
                 1
@@ -4107,7 +4108,8 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "int64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                 },
                 "valid": {
                     "description": "Valid is true if Int64 is not NULL",
@@ -5742,7 +5744,8 @@ const docTemplate = `{
                 "stackTrace": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "int32"
                     }
                 }
             }

--- a/control-plane/docs/swagger.json
+++ b/control-plane/docs/swagger.json
@@ -2843,7 +2843,8 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int32"
                             }
                         }
                     },
@@ -3609,7 +3610,7 @@
                     "$ref": "#/definitions/domain.CommonLbConfig"
                 },
                 "connectionIdleTimeout": {
-                    "type": "integer"
+                    "$ref": "#/definitions/domain.NullInt"
                 },
                 "dnsResolvers": {
                     "type": "array",
@@ -3698,6 +3699,7 @@
         },
         "domain.ConfigPriority": {
             "type": "integer",
+            "format": "int32",
             "enum": [
                 0,
                 1
@@ -4095,7 +4097,8 @@
             "type": "object",
             "properties": {
                 "int64": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "int64"
                 },
                 "valid": {
                     "description": "Valid is true if Int64 is not NULL",
@@ -5730,7 +5733,8 @@
                 "stackTrace": {
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "int32"
                     }
                 }
             }

--- a/control-plane/docs/swagger.yaml
+++ b/control-plane/docs/swagger.yaml
@@ -41,7 +41,7 @@ definitions:
       commonLbConfig:
         $ref: '#/definitions/domain.CommonLbConfig'
       connectionIdleTimeout:
-        "type": "integer"
+        $ref: '#/definitions/domain.NullInt'
       dnsResolvers:
         items:
           $ref: '#/definitions/domain.DnsResolver'
@@ -102,6 +102,7 @@ definitions:
     enum:
     - 0
     - 1
+    format: int32
     type: integer
     x-enum-varnames:
     - Product
@@ -363,6 +364,7 @@ definitions:
   domain.NullInt:
     properties:
       int64:
+        format: int64
         type: integer
       valid:
         description: Valid is true if Int64 is not NULL
@@ -1438,6 +1440,7 @@ definitions:
         type: string
       stackTrace:
         items:
+          format: int32
           type: integer
         type: array
     type: object
@@ -3584,6 +3587,7 @@ paths:
           description: OK
           schema:
             items:
+              format: int32
               type: integer
             type: array
         "500":


### PR DESCRIPTION
Missing comma symbol at swagger docs.

<img width="1125" height="125" alt="image" src="https://github.com/user-attachments/assets/5b2b8a65-213d-4f4c-b421-76204aafa986" />

I have regenerate docs via:
```bash
go:generate go run github.com/swaggo/swag/cmd/swag init --generalInfo /restcontrollers/v1/routes.go --parseDependency  --parseGoList=false --parseDepth 2
```
