### PR TITLE
fix: disable PackTraceReason and UseRequestIdForTraceSampling in envoy configuration

### DIFF
--- a/control-plane/application.yaml
+++ b/control-plane/application.yaml
@@ -1,7 +1,7 @@
 microservice:
   name: control-plane
   namespace: core-dev
-  
+
 http:
   server:
     bind: ":8080"


### PR DESCRIPTION
**Root cause analysis**
Modification of incoming X-Request-Id header by envoy is done for tracing:

- envoy packs tracing decision for request into 14th byte of X-Request-Id header in order to let know other envoys in chain should this request be sampled or not.
- Envoy considers that X-Request-Id is always UUIDv4, which means that this 14th byte in UUID always equals to '4', and there is no useful information in that. So from envoy perspective it is safe to change it.
- However, some other systems may break when trying to parse X-Request-Id as UUIDv4 since they expect '4' on this position of uuid.

Another issue caused by this envoy behavior that X-Request-Id in the same chain of requests can actually differ before and after request has passed the envoy.

**Proposed solution**
Now we use B3 headers to control tracing decisions so using this X-Request-Id approach in envoyproxy is redundant.

The following changes should be done in envoyproxy configuration to fix this issue:
need to extend HTTPConnectionManager of every listener with the following section:

```
request_id_extension:
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.request_id.uuid.v3.UuidRequestIdConfig
              pack_trace_reason: false
              use_request_id_for_trace_sampling: false
```

(see https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/request_id/uuid/v3/uuid.proto#envoy-v3-api-msg-extensions-request-id-uuid-v3-uuidrequestidconfig)

These changes should be done in control-plane microservice (for Service Mesh)