### PR TITLE
fix: ping unblock

### DIFF
--- a/control-plane/clustering/postgresql_service_test.go
+++ b/control-plane/clustering/postgresql_service_test.go
@@ -174,6 +174,10 @@ func (p *BlockingDbProviderStub) GetConn(ctx context.Context) (*bun.Conn, error)
 }
 
 func TestPostgreSqlService_Conn_PingTimeout(t *testing.T) {
+	original := dbCallTimeout
+	dbCallTimeout = 50 * time.Millisecond
+	defer func() { dbCallTimeout = original }()
+
 	service := NewPostgreSqlService(&BlockingDbProviderStub{})
 
 	conn, err := service.Conn()

--- a/control-plane/clustering/postgresql_service_test.go
+++ b/control-plane/clustering/postgresql_service_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
+	"testing"
+	"time"
+
 	"github.com/netcracker/qubership-core-control-plane/control-plane/v2/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/driver/pgdriver"
-	"net"
-	"testing"
-	"time"
 )
 
 // Test error cases
@@ -162,4 +163,23 @@ func findFreePort() int {
 	port := listener.Addr().(*net.TCPAddr).Port
 	_ = listener.Close()
 	return port
+}
+
+type BlockingDbProviderStub struct {
+	DbProviderStub
+}
+
+func (p *BlockingDbProviderStub) GetConn(ctx context.Context) (*bun.Conn, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestPostgreSqlService_Conn_PingTimeout(t *testing.T) {
+	service := NewPostgreSqlService(&BlockingDbProviderStub{})
+
+	conn, err := service.Conn()
+
+	assert.Nil(t, conn)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/control-plane/clustering/postgresql_service_test.go
+++ b/control-plane/clustering/postgresql_service_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net"
-	"testing"
-	"time"
-
 	"github.com/netcracker/qubership-core-control-plane/control-plane/v2/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/driver/pgdriver"
+	"net"
+	"testing"
+	"time"
 )
 
 // Test error cases

--- a/control-plane/clustering/sql_service.go
+++ b/control-plane/clustering/sql_service.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
-
 	"github.com/netcracker/qubership-core-control-plane/control-plane/v2/db"
 	"github.com/uptrace/bun"
+	"time"
 )
 
 var dbCallTimeout = 5 * time.Second

--- a/control-plane/clustering/sql_service.go
+++ b/control-plane/clustering/sql_service.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
+
 	"github.com/netcracker/qubership-core-control-plane/control-plane/v2/db"
 	"github.com/uptrace/bun"
-	"time"
 )
+
+var dbCallTimeout = 5 * time.Second
 
 var ctx = context.Background()
 
@@ -28,6 +31,10 @@ type SqlService interface {
 
 type PostgreSqlService struct {
 	dbProvider db.DBProvider
+}
+
+func newDBContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), dbCallTimeout)
 }
 
 func NewPostgreSqlService(dbProvider db.DBProvider) *PostgreSqlService {
@@ -118,6 +125,8 @@ func (p *PostgreSqlService) Count(cnn *bun.Conn) (int, error) {
 }
 
 func (p *PostgreSqlService) Conn() (*bun.Conn, error) {
+	ctx, cancel := newDBContext()
+	defer cancel()
 	return p.dbProvider.GetConn(ctx)
 }
 


### PR DESCRIPTION
**Problem Description**

During PostgreSQL maintenance, the control-plane was unable to reconnect to PostgreSQL after the database became available again. As a result, 16 namespaces were impacted because the control-plane remained stuck in the Phantom state and never recovered to the Master state.

**The root cause is as follows:**

- When PostgreSQL goes down, the existing TCP connections between the control-plane and PostgreSQL become half-open. These connections appear to be alive at the operating system level, but are no longer valid from the PostgreSQL server's perspective.
- When PostgreSQL comes back online, the control-plane invokes Ping() on these stale half-open connections.
- Ping() does not fail immediately. Instead, it blocks until the operating system determines that the TCP connection is no longer valid.
- On Linux/Kubernetes, the default TCP keepalive timeout is approximately 7200 seconds (2 hours). During this period, the operating system continues to treat the half-open connection as active.
- Since Ping() blocks, each leader election cycle also blocks. Consequently, GetMaster() returns nil, preventing the node from transitioning from the Phantom state to the Master state.
- Because the blocked Ping() never completes within a reasonable time, the connection cache is not evicted and a new PostgreSQL connection is not established, leaving the control-plane permanently stuck in the Phantom state.

**Solution**
During the investigation, we observed another namespace in the same environment that successfully recovered from the Phantom state to the Master state when Ping() failed quickly, confirming that fast failure allows the leader election process to recover.

We had previously encountered a similar issue where Ping() could block indefinitely. To address that issue, the DBaaS team introduced support for PingContext(), allowing database operations to be controlled using a context.

For the current issue, we leverage that DBaaS enhancement by invoking PingContext() with a context timeout. This ensures that if Ping() does not receive a response within the configured timeout, it fails with context.DeadlineExceeded instead of waiting for the operating system's TCP keepalive timeout.